### PR TITLE
Make the batch mode work even in Docker environment

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -34,7 +34,7 @@ check_optional_args() {
     case "$arg" in
       --batch)
         LAUNCH_ZSH_AFTER=0
-        printf "${BLUE}--batch:${NORMAL} zsh will not be started after installation\n"
+        printf "%s\n" "${BLUE}--batch:${NORMAL} zsh will not be started after installation"
         ;;
       *)
         printf "${YELLOW}Unrecognized argument: ${BLUE}${arg}${NORMAL}\n"

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -101,7 +101,7 @@ main() {
   mv -f ~/.zshrc-omztemp ~/.zshrc
 
   # If this user's login shell is not already "zsh", attempt to switch.
-  TEST_CURRENT_SHELL=$(expr "$SHELL" : '.*/\(.*\)')
+  TEST_CURRENT_SHELL=$(expr "${SHELL:=/bin/false}" : '.*/\(.*\)')
   if [ "$TEST_CURRENT_SHELL" != "zsh" ]; then
     # If this platform provides a "chsh" command (not Cygwin), do it, man!
     if hash chsh >/dev/null 2>&1; then


### PR DESCRIPTION
Hi, here are two small fixes to your installation script which make it work even when installed in some minimal environments (e.g., Docker), where no $SHELL variable has to be set and colors may be unsupported and thus some of the variables may be empty. Hopefully, it will make its way to the official repo. Thank you for your work.